### PR TITLE
Revert " 解决路径添加/gemini-viewer-examples/导致示例页面打不开问题"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "gemini-viewer-examples",
+  "name": "gemini-viewer-demo",
   "version": "0.1.0",
   "private": true,
-  "homepage": ".",
+  "homepage": "/gemini-viewer-examples/",
   "dependencies": {
     "@codemirror/autocomplete": "^6.3.0",
     "@codemirror/commands": "^6.1.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <React.StrictMode>
-      <HashRouter>
+      <HashRouter basename="/">
             <App />
       </HashRouter>
   </React.StrictMode>

--- a/src/pages/demo/index.tsx
+++ b/src/pages/demo/index.tsx
@@ -8,7 +8,7 @@ function Demo() {
     const [data, setData] = useState<MenusProp[]>([]);
 
     useEffect(() => {
-        fetch("./config.json").then(data => data.json()).then((data) => {
+        fetch("../gemini-viewer-examples/config.json").then(data => data.json()).then((data) => {
             setData(data);
         });
     }, [])


### PR DESCRIPTION
This reverts commit 47202b6698de7df6f8c8a28d8bd868910f395289.